### PR TITLE
add sealed secrets for cert-manager APIs

### DIFF
--- a/environments/dev/sealed-secrets/cert-manager-api-sealed-secret.yaml
+++ b/environments/dev/sealed-secrets/cert-manager-api-sealed-secret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+  creationTimestamp: null
+  name: cert-manager-api-secrets
+  namespace: dmp-roadmap-dev
+spec:
+  encryptedData:
+    CF_API_KEY: AgC/1cO3Gog6RFcIhuL4y9u1dbmpeD9B5skff5qlVldX8m3uSp9kDbPJdyfXGfdTN5QKQfQncHUVAX5ZQdkeJ2ACCfFwgz1RFTkWhwgyZH/3a9fZQNtQp/5d9nDUegLd9VMCLhlk355ZM2744JN7n8+evEGsOHoHPg1/JNJTpwos7UnNwyIj5JQ3M1zIlGk+O3vP6Hcvkmc7eNDGdCjCsVXkLFFKXq4FiPMbDG1t9Dglk+x/ntROKFYRGaybJIx0vMPMsr0lcltuzwwcE/M4t7uMujDDLRlujqrptMd+csLReQkWXaAGLlC/SPz25VSMOJQoEfEt3sRlai51aeNTvdMUdbPTn0HPQuy1Bodg40TQeK1SnfzL96s07VCE6iqXLxmE30LW+67LWbG/Q+a7nG7oEkv6BtifgL+YyEPClvK7kJFl4DsCNntyrgUqGX3bRWzl2T7M5M2TxHaEqQkWdOjt4xwDe/ho9pojFW5NazjJogKjbFqWS7wMyABrwYKe0BzMLJxUXe8ICApX0Pvn7Gh3AU4z2jZT7LwQABRH1IAsgMwfk/oreVwpyY9m9VKECq0dVGeOxlZRcaJdZg0ubC0xPl587bz+hlU1NQTmWTHpISwuviwfDa0iCc22WLmxK10llP81Rv3eqQj6BTsACWmEM+Ma+yoAzuNGBHeUYDY+ApJya2oINpI0597PB5tfisEIHfIJDcMRkf64/PfAJaCup6T3LZf87e6ubw9oA3HKSVe0+L9Yx8LH
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/part-of: argocd
+      name: cert-manager-api-secrets
+      namespace: dmp-roadmap-dev
+    type: Opaque

--- a/environments/prod/sealed-secrets/cert-manager-api-sealed-secret.yaml
+++ b/environments/prod/sealed-secrets/cert-manager-api-sealed-secret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+  creationTimestamp: null
+  name: cert-manager-api-secrets
+  namespace: dmp-roadmap-prod
+spec:
+  encryptedData:
+    CF_API_KEY: AgDEYH6kwmVuVTiv3m8DckfjT/mIDPQYUTwdwOiHmgzk+ho9DMRSvwxP6aE82IvmsNJ9jHfMBRFQm8qcDVo8hdoUJSvv9oHL6hVqwIeHXDB/GCDBoHvr58Emvl5iur73Rc1622aUYA9obXRByxKF5/59eJpEmMfqF14I+yZn1O/151ptFcTIloX9KFUnlijd3h0Z4T54ZT4yL6Yjymq2h76nDU8T4ZjVLtRnF5dcOBa7kUuhIw37e0yB0n4b/uNqYA99HDMyxT8D4zx04fXBvypmpv89+sN0wVsvoC//DIlN69GOIQj8g12feK2Tor6jZDMcheCzaOXjjCqs/Ii1Pp8nni+ahbpCrFPg7+BQr6j60IwBhG0rnsv9K5tx2PWX+szMQgCjwG4rSOoCFOdCkBib3Lx64NUBHR9KyZ+DZjsLuojRJcAisSwOB5GTgdKkShzzhzbeYOEWnNpAggpzu1gRiB546ZPR5ZrMRF0pEM3Erlm3I2vW+CI6vfBcB28N0PcASsFHsxDhCKUljfFe1e9YhDdKQh07NrwLyIdGiqIV0FSqqQknHjN9I24G3ubc4goPDdskGoDJxOeYEE2csCu1677iJ44Gc83iUcWgZ6U6G6vGEwwv5pvol2XudPdgxN0FLCfu0+Btd6LGS6X8jMPt5W248XxWfGqntizpuzriq1PY7tZtJLV/oXA2oQ99fYj+67tEuzbjXAG7D14Q8lvVZ/zUOS7BasKel1FxT9vB4hkw8tW2cUJQ
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/part-of: argocd
+      name: cert-manager-api-secrets
+      namespace: dmp-roadmap-prod
+    type: Opaque

--- a/environments/staging/sealed-secrets/cert-manager-api-sealed-secret.yaml
+++ b/environments/staging/sealed-secrets/cert-manager-api-sealed-secret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+  creationTimestamp: null
+  name: cert-manager-api-secrets
+  namespace: dmp-roadmap-staging
+spec:
+  encryptedData:
+    CF_API_KEY: AgDFqkoNhpa9uyj8svPZPv0dD6IB8cOUIICJOGYxSBdtkSiP/K25D5ZaGOMtYOdcMjqF+lGwiJq0J8jReInhI/6ZZgjwiWa7bGDgEPSIIISWZw+gHxuZlH0JMDnLTjptO86YIsL0yGDoABDeYYHVDR9W4Z5HxSjJlM0694RjkGBPGUk/TiG6tog/sr6U6D6kbhAQpiv2Jl+BMDsvnctTWMDilw4bWenGlj/gEkMxnjRJuR8xTwyN5KdLyhFZA2X1dXA3RP5QthbMsEUH2ApreblLhocEb1CKDnprIv/F6lXIgpLwGMnEb3Jqsqo9pWh7uovh8FzlNOCnBNTbfBhh3ltASD+CLlxLFuYfZ5C45q6TMXtrdEJJ8CvJZFopC+hsPb4ncMZRDWZrVoas2sGSH8EiQP/0j2eAQB/Ru1U5vf4aXgE9UlEmmI3Ed898zi56n9x13SsW/epM+bVeZupt3dCsy8xkG7SZuO+8QYFZ+Tbs0NHClWmTS/H6Q3C9tL1rZYjuhKkJNs0wcnzjA7sR1JYMsWVlpLwU8dlcJiBYdrm3fu0pUPiPg9cLOoG5fEP0QMIKqI78qMoJ78Rr5LfkLdUuUDuiImhrnL7FkU3uHpX5n6tbOFr2rOHeNL4ZtmQZNDoGUZQRLSGUpVSvmPRtM16RbdP468zcY2VgxxEzG1SfoRAvszkmXor+3/b4T8SbAtMQdBZXtxUmfUvGweqE1Dg1jBQ+SClOuY5oGXzEfwX3+1KxSrod00Rf
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/part-of: argocd
+      name: cert-manager-api-secrets
+      namespace: dmp-roadmap-staging
+    type: Opaque


### PR DESCRIPTION
## Description

Introduces sealed secrets for managing cert-manager API keys across different environments. This refines our secrets management by allowing us to securely store sensitive data while ensuring compatibility with GitOps principles.

The changes include environment-specific sealed secrets for development, production, and staging, facilitating controlled access to critical configurations.

## Type of Change

Please delete options that are not relevant.

- [X] Configuration update (environment-specific configuration changes)

## Environments Affected

- [X] All environments

## Testing

Describe the tests that you ran to verify your changes:

- [x] Local validation (YAML linting, etc.)
- [x] Helm template validation
- [x] ArgoCD application validation
- [x] Pre-commit hooks passed
- [x] GitHub Actions validation passed
- [x] Manual testing in development environment