### PR TITLE
enable automated sync for development environment

### DIFF
--- a/argocd/dmp-roadmap-dev.yaml
+++ b/argocd/dmp-roadmap-dev.yaml
@@ -3,9 +3,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
-    argocd.argoproj.io/manifest-generate-paths: >-
-      /environments/**;
-      /charts/**;
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: dmp-roadmap-dev
   namespace: dmp-roadmap-dev
@@ -31,6 +28,9 @@ spec:
       repoURL: https://github.com/portagenetwork/roadmap.git
       targetRevision: deployment-portage
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     retry:
       backoff:
         duration: 5s

--- a/argocd/dmp-roadmap-prod.yaml
+++ b/argocd/dmp-roadmap-prod.yaml
@@ -3,9 +3,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
-    argocd.argoproj.io/manifest-generate-paths: >-
-      /environments/**;
-      /charts/**;
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: dmp-roadmap-prod
   namespace: dmp-roadmap-prod
@@ -31,6 +28,9 @@ spec:
       repoURL: https://github.com/portagenetwork/roadmap.git
       targetRevision: deployment-portage
   syncPolicy:
+    # automated:
+    #   prune: true
+    #   selfHeal: true
     retry:
       backoff:
         duration: 5s

--- a/argocd/dmp-roadmap-staging.yaml
+++ b/argocd/dmp-roadmap-staging.yaml
@@ -3,9 +3,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
-    argocd.argoproj.io/manifest-generate-paths: >-
-      /environments/**;
-      /charts/**;
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: dmp-roadmap-staging
   namespace: dmp-roadmap-staging
@@ -31,6 +28,9 @@ spec:
       repoURL: https://github.com/portagenetwork/roadmap.git
       targetRevision: deployment-portage
   syncPolicy:
+    # automated:
+    #   prune: true
+    #   selfHeal: true
     retry:
       backoff:
         duration: 5s


### PR DESCRIPTION
## Description

Implements automated sync with prune and self-heal options for the development environment of the dmp-roadmap application. This reduces administrative overhead by ensuring the environment stays up-to-date with the latest changes in the repository.

These enhancements improve the reliability of deployments by enabling automatic recovery from drift, offering a more resilient infrastructure.

## Type of Change

- [ ] Configuration update (environment-specific configuration changes)

## Environments Affected

- [ ] Development
- [ ] Staging
- [ ] Production
- [ ] All environments
- [ ] N/A (documentation/tooling only)

## Changes Made

Detailed description of what was changed:

- enable auto sync for dev environment
- remove manifest-generator path as it isn't needed in a repo of this size

## Testing

Describe the tests that you ran to verify your changes:

- [ ] Local validation (YAML linting, etc.)
- [ ] Helm template validation
- [ ] ArgoCD application validation
- [ ] Pre-commit hooks passed
- [ ] GitHub Actions validation passed
- [ ] Manual testing in development environment