### PR TITLE
chore(dev): temporarily disable ArgoCD auto-sync

### DIFF
--- a/argocd/dmp-roadmap-dev.yaml
+++ b/argocd/dmp-roadmap-dev.yaml
@@ -28,9 +28,9 @@ spec:
       repoURL: https://github.com/portagenetwork/roadmap.git
       targetRevision: deployment-portage
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    # automated:
+    #   prune: true
+    #   selfHeal: true
     retry:
       backoff:
         duration: 5s


### PR DESCRIPTION
Temporarily disable ArgoCD automated sync and self-healing for the development environment to allow live deployment changes while investigating startup issues.

## What changed?

Brief description of the changes in this PR.

## Environments affected

- [x] Development
- [ ] Staging
- [ ] Production

## Validation

- [x] Pre-commit hooks passed
- [x] GitHub Actions passed
- [x] Sealed secrets are encrypted (if applicable)
- [x] No plaintext secrets

## Deployment notes

Any special deployment considerations or rollback steps?

## Additional context

Any other context reviewers should know?
