### PR TITLE
chore(staging): test startup probe chart

### DIFF
--- a/argocd/dmp-roadmap-staging.yaml
+++ b/argocd/dmp-roadmap-staging.yaml
@@ -26,7 +26,7 @@ spec:
           - $values/environments/staging/values.yaml
       path: charts/dmp-roadmap
       repoURL: https://github.com/portagenetwork/roadmap.git
-      targetRevision: deployment-portage
+      targetRevision: aaron/fix/add-startup-probe
   syncPolicy:
     # automated:
     #   prune: true


### PR DESCRIPTION
## What changed?

Update the staging ArgoCD application to use the startup probe chart branch for testing.

Point the DMP Roadmap Helm chart source at `aaron/fix/add-startup-probe` so the new `startupProbe` configuration can be validated in the staging environment before merging.

## Environments affected

- [ ] Development
- [x] Staging
- [ ] Production

## Validation

- [x] Pre-commit hooks passed
- [x] GitHub Actions passed
- [x] Sealed secrets are encrypted (if applicable)
- [x] No plaintext secrets

## Deployment notes

Any special deployment considerations or rollback steps?

## Additional context

Any other context reviewers should know?
