### PR TITLE
chore(argocd): restore dev and staging chart tracking

### DIFF
--- a/argocd/dmp-roadmap-dev.yaml
+++ b/argocd/dmp-roadmap-dev.yaml
@@ -26,7 +26,7 @@ spec:
           - $values/environments/dev/values.yaml
       path: charts/dmp-roadmap
       repoURL: https://github.com/portagenetwork/roadmap.git
-      targetRevision: aaron/fix/add-startup-probe
+      targetRevision: deployment-portage
   syncPolicy:
     automated:
       prune: true

--- a/argocd/dmp-roadmap-staging.yaml
+++ b/argocd/dmp-roadmap-staging.yaml
@@ -26,7 +26,7 @@ spec:
           - $values/environments/staging/values.yaml
       path: charts/dmp-roadmap
       repoURL: https://github.com/portagenetwork/roadmap.git
-      targetRevision: aaron/fix/add-startup-probe
+      targetRevision: deployment-portage
   syncPolicy:
     # automated:
     #   prune: true


### PR DESCRIPTION
## What changed?

Update dev and staging ArgoCD applications to track the `deployment-portage` branch after validating the startup probe changes.

This returns environments to the standard Helm chart source branch.


## Environments affected

- [x] Development
- [x] Staging
- [ ] Production

## Validation

- [x] Pre-commit hooks passed
- [x] GitHub Actions passed
- [x] Sealed secrets are encrypted (if applicable)
- [x] No plaintext secrets

## Deployment notes

Any special deployment considerations or rollback steps?

## Additional context

Any other context reviewers should know?
